### PR TITLE
add gsm detector package

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Montrons au monde que la CI produit du code de qualité, des outils de qualité.
 
 
 ## <a name="G"> </a>G
-
+* [Gsm detector](https://github.com/gabeta/gsm-detector) - Gsm Detector est un package PHP qui permet de connaitre le nom de l'opérateur d'un reseau GSM d'un numéro de téléphone donné. **Par [Gabeta Soro/ @GabetaSoro](https://github.com/gabeta)**
 
 ## <a name="H"> </a>H
 


### PR DESCRIPTION
Gsm Detector is a PHP package which allows to know the name of the GSM network of a given phone number.

